### PR TITLE
Refactor bundle size

### DIFF
--- a/conf/webpack-dist.conf.js
+++ b/conf/webpack-dist.conf.js
@@ -50,10 +50,6 @@ module.exports = {
     ]
   },
   plugins: [
-    // https://github.com/jmblog/how-to-optimize-momentjs-with-webpack
-    // Ignore all locale files of moment.js
-    new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
-
     new webpack.optimize.OccurrenceOrderPlugin(),
     new webpack.NoEmitOnErrorsPlugin(),
     new HtmlWebpackPlugin({

--- a/conf/webpack-dist.conf.js
+++ b/conf/webpack-dist.conf.js
@@ -50,6 +50,10 @@ module.exports = {
     ]
   },
   plugins: [
+    // https://github.com/jmblog/how-to-optimize-momentjs-with-webpack
+    // Ignore all locale files of moment.js
+    new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+
     new webpack.optimize.OccurrenceOrderPlugin(),
     new webpack.NoEmitOnErrorsPlugin(),
     new HtmlWebpackPlugin({

--- a/package-lock.json
+++ b/package-lock.json
@@ -9338,11 +9338,6 @@
         }
       }
     },
-    "moment": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
-      "integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ=="
-    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
     "angular-sanitize": "^1.6.9",
     "angularjs-datepicker": "^2.1.23",
     "autolinker": "^1.6.2",
-    "moment": "^2.21.0",
     "ng-dialog": "^1.4.0",
     "textangular": "^1.5.16",
     "ui-select": "^0.19.8"

--- a/src/app/services/auth.js
+++ b/src/app/services/auth.js
@@ -1,4 +1,3 @@
-import moment from 'moment';
 import { apiUrl } from '../../constants';
 
 export default class AuthService {
@@ -118,8 +117,8 @@ function tokenExpired(token) {
   }
   const base64 = base64Url.replace('-', '+').replace('_', '/');
   const parsedToken = angular.fromJson(this.$window.atob(base64));
-  const expiry = moment.unix(parsedToken.exp);
-  const current = moment();
-  const hasExpired = expiry.isBefore(current);
+  const expiry = new Date(parsedToken.exp * 1000);
+  const current = new Date();
+  const hasExpired = expiry < current;
   return hasExpired;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import angular from 'angular';
 import uiRouter from '@uirouter/angularjs';
 import ngSanitize from 'angular-sanitize';
 import ngDialog from 'ng-dialog';
-import textAngular from 'textAngular';
+import textAngular from 'textangular';
 import 'angularjs-datepicker';
 import uiselect from 'ui-select';
 import APIInterceptor from './app/services/apiInterceptor';
@@ -53,4 +53,3 @@ angular
   .component('serviceEdit', serviceEdit)
   .component('start', start)
   .component('tool', tool);
-  


### PR DESCRIPTION
Used the following to generate a webpack stats file:
```
NODE_ENV=production ./node_modules/.bin/webpack --config conf/webpack-dist.conf.js --profile --json > stats.json
```

And then used [webpack-bundle-analyzer](https://www.npmjs.com/package/webpack-bundle-analyzer) to see what was in the bundle.

I've split the improvements into separate commits for review.

* The `moment` locales were all being included, even though they weren't in use
* The `textAngular` dep was being duplicated because of the casing difference, fixed casing and it went away.

After those, the sizes were fairly similar, but still a bit bigger - but nothing really stood out as being a culprit.

There are still quite a few chunky third party dependencies - I did a quick check and noticed moment looked easy enough to factor away. I haven't tested the functionality I replaced though - wasn't sure exactly how to.

